### PR TITLE
Module Import Test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+import-test.tsx

--- a/.github/workflows/cra.yml
+++ b/.github/workflows/cra.yml
@@ -1,0 +1,53 @@
+name: Module Import
+
+on:
+    push:
+        branches: [master, test/CRAinstall]
+    pull_request:
+        branches: [master]
+
+jobs:
+    test_import:
+        runs-on: ubuntu-latest
+        env:
+            CRA: 'async-storage-tester'
+            RAS: 'react-async-storage'
+            WORKDIR: '/home/runner/work/react-async-storage/react-async-storage'
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2-beta
+              with:
+                  node-version: '15'
+                  check-latest: true
+
+            - name: ⚛️ Create React App
+              run: >-
+                  yarn create react-app ${{env.CRA}} --template typescript &&
+                  cd ${{env.CRA}} && yarn add @types/lodash.merge localforage
+
+            - name: ⛓ Copy Source
+              run: >-
+                  cd $WORKDIR &&
+                  mkdir -p $WORKDIR/${{env.CRA}}/node_modules/${{env.RAS}}/src &&
+                  cp index.d.ts ${{env.CRA}}/node_modules/${{env.RAS}}/index.d.ts &&
+                  cp tsconfig.json ${{env.CRA}}/node_modules/${{env.RAS}}/tsconfig.json &&
+                  cp rollup.config.js ${{env.CRA}}/node_modules/${{env.RAS}}/rollup.config.js &&
+                  cp package.json ${{env.CRA}}/node_modules/${{env.RAS}}/package.json &&
+                  cp .prettierrc ${{env.CRA}}/node_modules/${{env.RAS}}/.prettierrc &&
+                  cp yarn.lock ${{env.CRA}}/node_modules/${{env.RAS}}/yarn.lock &&
+                  cp -r src/* ${{env.CRA}}/node_modules/${{env.RAS}}/src
+
+            - name: 🏋🏼‍♀️ Build Node Module
+              run: >-
+                  cd $WORKDIR/${{env.CRA}}/node_modules/${{env.RAS}} &&
+                  yarn --pure-lockfile --ignore-scripts &&
+                  cd .. && cd ${{env.RAS}} &&
+                  yarn build
+
+            - name: 📥 Test Module Import
+              run: >-
+                  cd $WORKDIR &&
+                  rm -f ${{env.CRA}}/src/App.ts ${{env.CRA}}/src/App.tsx &&
+                  cp import-test.tsx ${{env.CRA}}/src/App.tsx &&
+                  cd ${{env.CRA}} &&
+                  yarn build

--- a/.github/workflows/cra.yml
+++ b/.github/workflows/cra.yml
@@ -2,7 +2,7 @@ name: Module Import
 
 on:
     push:
-        branches: [master, test/CRAinstall]
+        branches: [master]
     pull_request:
         branches: [master]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:15-alpine
+RUN apk --no-cache add git
+
+ARG RAS='react-async-storage'
+ARG CRA='async-storage-tester'
+
+RUN yarn create react-app ${CRA} --template typescript
+RUN cd ${CRA} && \
+	  yarn add @types/lodash.merge localforage
+
+WORKDIR /${CRA}
+RUN rm -f src/App.ts src/App.tsx
+COPY import-test.tsx src/App.tsx
+COPY index.d.ts node_modules/${RAS}/index.d.ts
+COPY tsconfig.json node_modules/${RAS}/tsconfig.json
+COPY rollup.config.js node_modules/${RAS}/rollup.config.js
+COPY package.json node_modules/${RAS}/package.json
+COPY .prettierrc node_modules/${RAS}/.prettierrc
+COPY yarn.lock node_modules/${RAS}/yarn.lock
+COPY src node_modules/${RAS}/src
+
+WORKDIR /${CRA}/node_modules/${RAS}
+RUN yarn --frozen-lockfile --ignore-scripts
+RUN yarn build
+RUN cd ../.. && yarn build

--- a/import-test.tsx
+++ b/import-test.tsx
@@ -1,0 +1,27 @@
+import { StorageProvider } from 'react-async-storage'
+import React, { useEffect, useState } from 'react'
+
+const StorageComponent = () => {
+    const [test, setTest] = useState<null | string>(null)
+    useEffect(() => {
+        const ls = localStorage.getItem('test')
+        setTest(ls)
+        localStorage.setItem('test', 'success')
+    }, [])
+
+    return <>{test ?? 'failure'}</>
+}
+
+function App() {
+    return (
+        <div className="App">
+            <StorageProvider>
+                <p>
+                    <StorageComponent />
+                </p>
+            </StorageProvider>
+        </div>
+    )
+}
+
+export default App

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as ReactAsyncStorage from './src'
+declare module 'react-async-storage' {
+    export * from './src'
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
         "lint:script": "eslint --fix '**/*.{ts,tsx,*.ts,*.tsx}'",
         "postpublish": "rimraf dist",
         "prepublishOnly": "yarn build",
-        "test": "jest --silent"
+        "test": "jest --silent",
+        "test:install": "docker build ."
     },
     "husky": {
         "hooks": {


### PR DESCRIPTION
I am totally open to removing the Dockerfile. The idea was just to fail early, e.g. by working this local test into the prePublish script. I added it in the first place to set up the basic structure of the cra.yml workflow – and I do see that having docker in here as an external dependency is probably not the way to go.